### PR TITLE
remove dependency from local .babelrc file

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -43,7 +43,8 @@ gulp.task('minifyJS', function() {
     return gulp.src(config.jsFile)
       .pipe(jsValidate())
       .pipe(gulpIf(config.babel, babel({
-        presets: ['es2015']
+        presets: ['es2015'],
+		babelrc: false
       })))
       .pipe(replace(/('|")use strict\1/g, ''))
       .pipe(rename({suffix: '.min'}))


### PR DESCRIPTION
not really going to be applicable to most, but this resolved a local issue i've been having with the tool in that it was reading my ~/.babelrc file and causing errors because of it. it's a preventative measure in the event that anyone in the future needs to configure a .babelrc file for something like webpack or other bundling tools and have it not apply to the tool.